### PR TITLE
feat: Add CHF as a currency option

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,6 +176,7 @@ input[type="checkbox"] {
     <select id="currency">
       <option value="EUR">EUR</option>
       <option value="USD">USD</option>
+      <option value="CHF">CHF</option>
     </select>
   </div>
 

--- a/script.js
+++ b/script.js
@@ -96,7 +96,7 @@ function updateValues(source) {
 
 // === Get BTC rate from multiple exchanges and compute median ===
 async function updateRates() {
-  const suffix = currency === "EUR" ? "eur" : "usd";
+  const suffix = currency.toLowerCase();
   const updated = await Promise.all(exchanges.map(ex =>
     fetch(ex.url.replace(/eur/gi, suffix))
       .then(res => res.json())


### PR DESCRIPTION
This commit introduces Swiss Francs (CHF) as a selectable currency in the dropdown menu.

The following changes were made:
- Added "CHF" to the currency selection dropdown in `index.html`.
- Updated the `updateRates` function in `script.js` to be more dynamic, allowing it to fetch exchange rates for any currency symbol (EUR, USD, CHF) by using the lowercase currency code as the API suffix.